### PR TITLE
idsueye: Update library name to avoid double lib

### DIFF
--- a/sys/idsueye/CMakeLists.txt
+++ b/sys/idsueye/CMakeLists.txt
@@ -7,7 +7,7 @@ set (HEADERS
 include_directories (AFTER
   ${IDSUEYE_INCLUDE_DIR})
 
-set (libname libgstidsueye)
+set (libname gstidsueye)
 
 add_library (${libname} MODULE
   ${SOURCES}


### PR DESCRIPTION
i have seen this with others as well. it will output liblibgstidsueye otherwise. 
probably a better fix upstairs is possible.