### PR TITLE
Bugfix/pylonsrc handle corupt frames

### DIFF
--- a/sys/pylon/gstpylonsrc.c
+++ b/sys/pylon/gstpylonsrc.c
@@ -501,29 +501,29 @@ gst_pylonsrc_class_init (GstPylonSrcClass * klass)
           (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
     g_object_class_install_property (gobject_class, PROP_PACKETSIZE,
       g_param_spec_int ("packetsize", "Maximum size of data packet",
-          "The packetsize parameter specifies the maximum size of a data packet transmitted via Ethernet. The value is in bytes.",
+          "The packetsize parameter specifies the maximum size of a data packet transmitted via Ethernet. The value is in bytes. Default value 0 -> Use camera defaults",
           0, 16404, 0,
-          (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
+          (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS))); //TODO: Limits may be co-dependent on other transport layer parameters.
       g_object_class_install_property (gobject_class, PROP_INTERPACKETDELAY,
       g_param_spec_int ("interpacketdelay", "Inter-Packet Delay between packet transmissions",
-          "If your network hardware can't handle the incoming packet rate, it is useful to increase the delay between packet transmissions.",
-          0, 3435, -1,
-          (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
+          "If your network hardware can't handle the incoming packet rate, it is useful to increase the delay between packet transmissions.  Default value -1 -> Use camera defaults",
+          -1, 273331, -1,
+          (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS))); //TODO: Limits may be co-dependent on other transport layer parameters
       g_object_class_install_property (gobject_class, PROP_FRAMETRANSDELAY,
       g_param_spec_int ("frametransdelay", "Delay for begin transmitting frame.",
-          "Sets a delay in ticks between when camera begisn transmitting frame afther acquiring it. By default, one tick equals 8 ns. With PTP enabled, one tick equals 1 ns.",
-          0, 50000000, -1,
-          (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
+          "Sets a delay in ticks between when camera begisn transmitting frame afther acquiring it. By default, one tick equals 8 ns. With PTP enabled, one tick equals 1 ns.  Default value -1 -> Use camera defaults",
+          -1, 50000000, -1,
+          (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS))); //TODO: Limits may be co-dependent on other transport layer parameters
       g_object_class_install_property (gobject_class, PROP_BANDWIDTHRESERVE,
       g_param_spec_int ("bandwidthreserve", "Portion of bandwidth reserved for packet resends.",
           "The setting is expressed as a percentage of the assigned bandwidth.",
-          0, 26, -1,
-          (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
+          -1, 200, -1,
+          (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS))); //TODO: Limits may be co-dependent on other transport layer parameters
       g_object_class_install_property (gobject_class, PROP_BANDWIDTHRESERVEACC,
       g_param_spec_int ("bandwidthreserveacc", "Pool of resends for unusual situations",
-          "For situations when the network connection becomes unstable. A larger number of packet resends may be needed to transmit an image",
-          1, 32, 0,
-          (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));        
+          "For situations when the network connection becomes unstable. A larger number of packet resends may be needed to transmit an image.  Default value 0 -> Use camera defaults",
+          0, 200, 0,
+          (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));//TODO: Limits may be co-dependent on other transport layer parameters    
 }
 
 static gboolean
@@ -2743,10 +2743,10 @@ gst_pylonsrc_configure_start_acquisition (GstPylonSrc * src)
       !gst_pylonsrc_set_readout (src) ||
       !gst_pylonsrc_set_bandwidth (src) ||
       !gst_pylonsrc_set_framerate (src) ||
-      !gst_pylonsrc_set_interPacketDelay(src) ||
       !gst_pylonsrc_set_frameTransDelay(src) ||
       !gst_pylonsrc_set_bandwidthReserveAcc(src) ||
       !gst_pylonsrc_set_bandwidthReserve(src) ||
+      !gst_pylonsrc_set_interPacketDelay(src) ||
       !gst_pylonsrc_set_lightsource (src) ||
       !gst_pylonsrc_set_auto_exp_gain_wb (src) ||
       !gst_pylonsrc_set_color (src) ||

--- a/sys/pylon/gstpylonsrc.c
+++ b/sys/pylon/gstpylonsrc.c
@@ -2815,7 +2815,7 @@ gst_pylonsrc_create (GstPushSrc * psrc, GstBuffer ** buf)
 
     vf->buffer_handle = grabResult.hBuffer;
     vf->src = src;
-    
+
     if (grabResult.Status != Grabbed ){
       src->failedFrames += 1;
       GST_WARNING_OBJECT (src,"Failed capture count=%d. Status=%d",src->failedFrames,grabResult.Status);      
@@ -2830,7 +2830,6 @@ gst_pylonsrc_create (GstPushSrc * psrc, GstBuffer ** buf)
   GST_BUFFER_OFFSET (*buf) = src->frameNumber;
   src->frameNumber += 1;
   GST_BUFFER_OFFSET_END (*buf) = src->frameNumber;
-  src->failedFrames = 0;
   
   return GST_FLOW_OK;
 error:

--- a/sys/pylon/gstpylonsrc.h
+++ b/sys/pylon/gstpylonsrc.h
@@ -61,7 +61,7 @@ struct _GstPylonSrc
   // Plugin parameters
   _Bool setFPS, continuousMode, limitBandwidth, demosaicing, centerx, centery, flipx, flipy;
   double fps, exposure, gain, blacklevel, gamma, balancered, balanceblue, balancegreen, redhue, redsaturation, yellowhue, yellowsaturation, greenhue, greensaturation, cyanhue, cyansaturation, bluehue, bluesaturation, magentahue, magentasaturation, sharpnessenhancement, noisereduction, autoexposureupperlimit, autoexposurelowerlimit, gainupperlimit, gainlowerlimit, brightnesstarget, transformation00, transformation01, transformation02, transformation10, transformation11, transformation12, transformation20, transformation21, transformation22;
-  gint height, width, binningh, binningv, maxHeight, maxWidth, maxBandwidth, testImage, offsetx, offsety, failrate, grabtimeout, packetSize;
+  gint height, width, binningh, binningv, maxHeight, maxWidth, maxBandwidth, testImage, offsetx, offsety, failrate, grabtimeout, packetSize, interPacketDelay;
   gchar *pixel_format, *sensorMode, *lightsource, *autoexposure, *autowhitebalance, *autogain, *reset, *autoprofile, *transformationselector, *userid;
 };
 

--- a/sys/pylon/gstpylonsrc.h
+++ b/sys/pylon/gstpylonsrc.h
@@ -61,7 +61,7 @@ struct _GstPylonSrc
   // Plugin parameters
   _Bool setFPS, continuousMode, limitBandwidth, demosaicing, centerx, centery, flipx, flipy;
   double fps, exposure, gain, blacklevel, gamma, balancered, balanceblue, balancegreen, redhue, redsaturation, yellowhue, yellowsaturation, greenhue, greensaturation, cyanhue, cyansaturation, bluehue, bluesaturation, magentahue, magentasaturation, sharpnessenhancement, noisereduction, autoexposureupperlimit, autoexposurelowerlimit, gainupperlimit, gainlowerlimit, brightnesstarget, transformation00, transformation01, transformation02, transformation10, transformation11, transformation12, transformation20, transformation21, transformation22;
-  gint height, width, binningh, binningv, maxHeight, maxWidth, maxBandwidth, testImage, offsetx, offsety, failrate, grabtimeout, packetSize, interPacketDelay, frameTransDelay;
+  gint height, width, binningh, binningv, maxHeight, maxWidth, maxBandwidth, testImage, offsetx, offsety, failrate, grabtimeout, packetSize, interPacketDelay, frameTransDelay, bandwidthReserve;
   gchar *pixel_format, *sensorMode, *lightsource, *autoexposure, *autowhitebalance, *autogain, *reset, *autoprofile, *transformationselector, *userid;
 };
 

--- a/sys/pylon/gstpylonsrc.h
+++ b/sys/pylon/gstpylonsrc.h
@@ -56,11 +56,12 @@ struct _GstPylonSrc
   int32_t frameSize; // Size of a frame in bytes.
   int32_t payloadSize; // Size of a frame in bytes.
   guint64 frameNumber; // Fun note: At 120fps it will take around 4 billion years to overflow this variable.
+  gint failedFrames; // Count of concecutive frames that have failed.
   
   // Plugin parameters
   _Bool setFPS, continuousMode, limitBandwidth, demosaicing, centerx, centery, flipx, flipy;
   double fps, exposure, gain, blacklevel, gamma, balancered, balanceblue, balancegreen, redhue, redsaturation, yellowhue, yellowsaturation, greenhue, greensaturation, cyanhue, cyansaturation, bluehue, bluesaturation, magentahue, magentasaturation, sharpnessenhancement, noisereduction, autoexposureupperlimit, autoexposurelowerlimit, gainupperlimit, gainlowerlimit, brightnesstarget, transformation00, transformation01, transformation02, transformation10, transformation11, transformation12, transformation20, transformation21, transformation22;
-  gint height, width, binningh, binningv, maxHeight, maxWidth, maxBandwidth, testImage, offsetx, offsety;
+  gint height, width, binningh, binningv, maxHeight, maxWidth, maxBandwidth, testImage, offsetx, offsety, failrate;
   gchar *pixel_format, *sensorMode, *lightsource, *autoexposure, *autowhitebalance, *autogain, *reset, *autoprofile, *transformationselector, *userid;
 };
 

--- a/sys/pylon/gstpylonsrc.h
+++ b/sys/pylon/gstpylonsrc.h
@@ -61,7 +61,7 @@ struct _GstPylonSrc
   // Plugin parameters
   _Bool setFPS, continuousMode, limitBandwidth, demosaicing, centerx, centery, flipx, flipy;
   double fps, exposure, gain, blacklevel, gamma, balancered, balanceblue, balancegreen, redhue, redsaturation, yellowhue, yellowsaturation, greenhue, greensaturation, cyanhue, cyansaturation, bluehue, bluesaturation, magentahue, magentasaturation, sharpnessenhancement, noisereduction, autoexposureupperlimit, autoexposurelowerlimit, gainupperlimit, gainlowerlimit, brightnesstarget, transformation00, transformation01, transformation02, transformation10, transformation11, transformation12, transformation20, transformation21, transformation22;
-  gint height, width, binningh, binningv, maxHeight, maxWidth, maxBandwidth, testImage, offsetx, offsety, failrate, grabtimeout, packetSize, interPacketDelay, frameTransDelay, bandwidthReserve;
+  gint height, width, binningh, binningv, maxHeight, maxWidth, maxBandwidth, testImage, offsetx, offsety, failrate, grabtimeout, packetSize, interPacketDelay, frameTransDelay, bandwidthReserve, bandwidthReserveAcc;
   gchar *pixel_format, *sensorMode, *lightsource, *autoexposure, *autowhitebalance, *autogain, *reset, *autoprofile, *transformationselector, *userid;
 };
 

--- a/sys/pylon/gstpylonsrc.h
+++ b/sys/pylon/gstpylonsrc.h
@@ -61,7 +61,7 @@ struct _GstPylonSrc
   // Plugin parameters
   _Bool setFPS, continuousMode, limitBandwidth, demosaicing, centerx, centery, flipx, flipy;
   double fps, exposure, gain, blacklevel, gamma, balancered, balanceblue, balancegreen, redhue, redsaturation, yellowhue, yellowsaturation, greenhue, greensaturation, cyanhue, cyansaturation, bluehue, bluesaturation, magentahue, magentasaturation, sharpnessenhancement, noisereduction, autoexposureupperlimit, autoexposurelowerlimit, gainupperlimit, gainlowerlimit, brightnesstarget, transformation00, transformation01, transformation02, transformation10, transformation11, transformation12, transformation20, transformation21, transformation22;
-  gint height, width, binningh, binningv, maxHeight, maxWidth, maxBandwidth, testImage, offsetx, offsety, failrate;
+  gint height, width, binningh, binningv, maxHeight, maxWidth, maxBandwidth, testImage, offsetx, offsety, failrate, grabtimeout;
   gchar *pixel_format, *sensorMode, *lightsource, *autoexposure, *autowhitebalance, *autogain, *reset, *autoprofile, *transformationselector, *userid;
 };
 

--- a/sys/pylon/gstpylonsrc.h
+++ b/sys/pylon/gstpylonsrc.h
@@ -61,7 +61,7 @@ struct _GstPylonSrc
   // Plugin parameters
   _Bool setFPS, continuousMode, limitBandwidth, demosaicing, centerx, centery, flipx, flipy;
   double fps, exposure, gain, blacklevel, gamma, balancered, balanceblue, balancegreen, redhue, redsaturation, yellowhue, yellowsaturation, greenhue, greensaturation, cyanhue, cyansaturation, bluehue, bluesaturation, magentahue, magentasaturation, sharpnessenhancement, noisereduction, autoexposureupperlimit, autoexposurelowerlimit, gainupperlimit, gainlowerlimit, brightnesstarget, transformation00, transformation01, transformation02, transformation10, transformation11, transformation12, transformation20, transformation21, transformation22;
-  gint height, width, binningh, binningv, maxHeight, maxWidth, maxBandwidth, testImage, offsetx, offsety, failrate, grabtimeout;
+  gint height, width, binningh, binningv, maxHeight, maxWidth, maxBandwidth, testImage, offsetx, offsety, failrate, grabtimeout, packetSize;
   gchar *pixel_format, *sensorMode, *lightsource, *autoexposure, *autowhitebalance, *autogain, *reset, *autoprofile, *transformationselector, *userid;
 };
 

--- a/sys/pylon/gstpylonsrc.h
+++ b/sys/pylon/gstpylonsrc.h
@@ -61,7 +61,7 @@ struct _GstPylonSrc
   // Plugin parameters
   _Bool setFPS, continuousMode, limitBandwidth, demosaicing, centerx, centery, flipx, flipy;
   double fps, exposure, gain, blacklevel, gamma, balancered, balanceblue, balancegreen, redhue, redsaturation, yellowhue, yellowsaturation, greenhue, greensaturation, cyanhue, cyansaturation, bluehue, bluesaturation, magentahue, magentasaturation, sharpnessenhancement, noisereduction, autoexposureupperlimit, autoexposurelowerlimit, gainupperlimit, gainlowerlimit, brightnesstarget, transformation00, transformation01, transformation02, transformation10, transformation11, transformation12, transformation20, transformation21, transformation22;
-  gint height, width, binningh, binningv, maxHeight, maxWidth, maxBandwidth, testImage, offsetx, offsety, failrate, grabtimeout, packetSize, interPacketDelay;
+  gint height, width, binningh, binningv, maxHeight, maxWidth, maxBandwidth, testImage, offsetx, offsety, failrate, grabtimeout, packetSize, interPacketDelay, frameTransDelay;
   gchar *pixel_format, *sensorMode, *lightsource, *autoexposure, *autowhitebalance, *autogain, *reset, *autoprofile, *transformationselector, *userid;
 };
 


### PR DESCRIPTION
This should help solve issue #14 handling corrupt frames.

I found that many errors occurred because the transport layer not being able to keep up with the frame-rate and packet size required for the application.  This can also be seen when connecting through the PylonViewer that comes with the Pylon SDK.

The parameters added helps with optimizing the bandwidth usage. And creates some tolerance for error messages related to incomplete packages.