### PR TITLE
pylon refactoring

### DIFF
--- a/sys/pylon/gstpylonsrc.h
+++ b/sys/pylon/gstpylonsrc.h
@@ -37,13 +37,13 @@ int gst_pylonsrc_unref_pylon_environment();
 enum {
   GST_PYLONSRC_NUM_CAPTURE_BUFFERS = 10,
   GST_PYLONSRC_NUM_AUTO_FEATURES = 3,
-  GST_PYLONSRC_NUM_MANUAL_FEATURES = 2,
   GST_PYLONSRC_NUM_LIMITED_FEATURES = 2
 };
 
 typedef struct _GstPylonSrcLimitedFeature {
   double lower;
   double upper;
+  double manual;
 } GstPylonSrcLimitedFeature;
 
 G_BEGIN_DECLS
@@ -87,7 +87,6 @@ struct _GstPylonSrc
   double saturation[6];
   double transformation[3][3];
 
-  double manualFeature[GST_PYLONSRC_NUM_MANUAL_FEATURES];
   GstPylonSrcLimitedFeature limitedFeature[GST_PYLONSRC_NUM_LIMITED_FEATURES];
 
   gint maxBandwidth, testImage;

--- a/sys/pylon/gstpylonsrc.h
+++ b/sys/pylon/gstpylonsrc.h
@@ -70,9 +70,20 @@ struct _GstPylonSrc
   guint64 frameNumber; // Fun note: At 120fps it will take around 4 billion years to overflow this variable.
   
   // Plugin parameters
-  _Bool setFPS, continuousMode, limitBandwidth, demosaicing, centerx, centery, flipx, flipy;
-  double fps, exposure, gain, blacklevel, gamma, balancered, balanceblue, balancegreen, redhue, redsaturation, yellowhue, yellowsaturation, greenhue, greensaturation, cyanhue, cyansaturation, bluehue, bluesaturation, magentahue, magentasaturation, sharpnessenhancement, noisereduction, autoexposureupperlimit, autoexposurelowerlimit, gainupperlimit, gainlowerlimit, brightnesstarget, transformation00, transformation01, transformation02, transformation10, transformation11, transformation12, transformation20, transformation21, transformation22;
-  gint height, width, binningh, binningv, maxHeight, maxWidth, maxBandwidth, testImage, offsetx, offsety;
+  _Bool setFPS, continuousMode, limitBandwidth, demosaicing;
+  _Bool center[2];
+  _Bool flip[2];
+  double fps, exposure, gain, blacklevel, gamma, sharpnessenhancement, noisereduction, autoexposureupperlimit, autoexposurelowerlimit, gainupperlimit, gainlowerlimit, brightnesstarget;
+  double balance[3];
+  double hue[6];
+  double saturation[6];
+  double transformation[3][3];
+
+  gint maxBandwidth, testImage;
+  gint size[2];
+  gint binning[2];
+  gint maxSize[2];
+  gint offset[2];
   gchar *pixel_format, *sensorMode, *lightsource, *autoexposure, *autowhitebalance, *autogain, *reset, *autoprofile, *transformationselector, *userid;
 };
 

--- a/sys/pylon/gstpylonsrc.h
+++ b/sys/pylon/gstpylonsrc.h
@@ -35,8 +35,16 @@ int gst_pylonsrc_ref_pylon_environment();
 int gst_pylonsrc_unref_pylon_environment();
 
 enum {
-  GST_PYLONSRC_NUM_CAPTURE_BUFFERS = 10
+  GST_PYLONSRC_NUM_CAPTURE_BUFFERS = 10,
+  GST_PYLONSRC_NUM_AUTO_FEATURES = 3,
+  GST_PYLONSRC_NUM_MANUAL_FEATURES = 2,
+  GST_PYLONSRC_NUM_LIMITED_FEATURES = 2
 };
+
+typedef struct _GstPylonSrcLimitedFeature {
+  double lower;
+  double upper;
+} GstPylonSrcLimitedFeature;
 
 G_BEGIN_DECLS
 
@@ -73,18 +81,22 @@ struct _GstPylonSrc
   _Bool setFPS, continuousMode, limitBandwidth, demosaicing;
   _Bool center[2];
   _Bool flip[2];
-  double fps, exposure, gain, blacklevel, gamma, sharpnessenhancement, noisereduction, autoexposureupperlimit, autoexposurelowerlimit, gainupperlimit, gainlowerlimit, brightnesstarget;
+  double fps, blacklevel, gamma, sharpnessenhancement, noisereduction, brightnesstarget;
   double balance[3];
   double hue[6];
   double saturation[6];
   double transformation[3][3];
+
+  double manualFeature[GST_PYLONSRC_NUM_MANUAL_FEATURES];
+  GstPylonSrcLimitedFeature limitedFeature[GST_PYLONSRC_NUM_LIMITED_FEATURES];
 
   gint maxBandwidth, testImage;
   gint size[2];
   gint binning[2];
   gint maxSize[2];
   gint offset[2];
-  gchar *pixel_format, *sensorMode, *lightsource, *autoexposure, *autowhitebalance, *autogain, *reset, *autoprofile, *transformationselector, *userid;
+  gchar *pixel_format, *sensorMode, *lightsource, *reset, *autoprofile, *transformationselector, *userid;
+  gchar* autoFeature[GST_PYLONSRC_NUM_AUTO_FEATURES];
 };
 
 struct _GstPylonSrcClass


### PR DESCRIPTION
Made some refactoring to gstpylonsrc.c. There were lots of repetative code (e.g. color adjustments for red, green, blue is identical).

I'm improving only pylonsrc plugin and now I'm heading towards using PylonFeaturePersistenceLoad() to use configuration files to set all features. Generally it's because of not all of them work properly on both my cameras. For example one camera does not have AcquisitionFrameRate feature, but has AquisitionFrameRateAbs.
Using configuration file will somewhat conflict with some features being set to default if not set explicitly. So I will use tri-state flags to determine if feature is set/notset/default.
If configuration file is not used, all features will be processed in "legacy" mode for compatibility, i.e if it is not set explicitly, it is default.
If configuration file is used, all features will be marked as notset if not set explicitly.

I'm also thinking of modifying CMakeLists to be able to specify GStreamer install prefix manually, because I've installed GStreamer with gst-build and it does not set any environment variables and pkg-config knows nothing about installation.