### PR TITLE
Pylon Feature Duplicates

### DIFF
--- a/sys/pylon/CMakeLists.txt
+++ b/sys/pylon/CMakeLists.txt
@@ -25,6 +25,12 @@ target_link_libraries (${libname}
   ${PYLON_LIBRARIES}
   )
 
+if(MSVC)
+  target_compile_options(${libname} PRIVATE /W4)
+else()
+  target_compile_options(${libname} PRIVATE -Wall)
+endif()
+
 if (WIN32)
   install (FILES $<TARGET_PDB_FILE:${libname}> DESTINATION ${PDB_INSTALL_DIR} COMPONENT pdb OPTIONAL)
 endif ()

--- a/sys/pylon/gstpylonsrc.c
+++ b/sys/pylon/gstpylonsrc.c
@@ -174,7 +174,7 @@ typedef enum _GST_PYLONSRC_PROP
       // But this way you can intuitively access propFlags[] by index
 } GST_PYLONSRC_PROP;
 
-G_STATIC_ASSERT (PROP_NUM_PROPERTIES == GST_PYLONSRC_NUM_PROPS);
+G_STATIC_ASSERT ((int)PROP_NUM_PROPERTIES == GST_PYLONSRC_NUM_PROPS);
 
 typedef enum _GST_PYLONSRC_AUTOFEATURE
 {
@@ -187,8 +187,8 @@ typedef enum _GST_PYLONSRC_AUTOFEATURE
   AUTOF_NUM_LIMITED = 2
 } GST_PYLONSRC_AUTOFEATURE;
 
-G_STATIC_ASSERT (AUTOF_NUM_FEATURES == GST_PYLONSRC_NUM_AUTO_FEATURES);
-G_STATIC_ASSERT (AUTOF_NUM_LIMITED == GST_PYLONSRC_NUM_LIMITED_FEATURES);
+G_STATIC_ASSERT ((int)AUTOF_NUM_FEATURES == GST_PYLONSRC_NUM_AUTO_FEATURES);
+G_STATIC_ASSERT ((int)AUTOF_NUM_LIMITED == GST_PYLONSRC_NUM_LIMITED_FEATURES);
 
 static const char *const featAutoFeature[AUTOF_NUM_FEATURES] =
     { "GainAuto", "ExposureAuto", "BalanceWhiteAuto" };
@@ -2614,7 +2614,7 @@ static gboolean
 gst_pylonsrc_configure_start_acquisition (GstPylonSrc * src)
 {
   GENAPIC_RESULT res;
-  gint i;
+  size_t i;
   size_t num_streams;
 
   // Create a stream grabber
@@ -2842,7 +2842,7 @@ gst_pylonsrc_read_offset (GstPylonSrc * src)
   gst_pylonsrc_read_offset_axis (src, AXIS_Y);
 }
 
-static _Bool
+static void
 gst_pylonsrc_read_reverse_axis (GstPylonSrc * src, GST_PYLONSRC_AXIS axis)
 {
   if (is_prop_not_set (src, propReverse[axis])) {
@@ -3004,8 +3004,6 @@ gst_pylonsrc_read_limited_feature (GstPylonSrc * src,
 static void
 gst_pylonsrc_read_auto_exp_gain_wb (GstPylonSrc * src)
 {
-  GENAPIC_RESULT res;
-
   for (int i = 0; i < AUTOF_NUM_FEATURES; i++) {
     gst_pylonsrc_read_auto_feature (src, (GST_PYLONSRC_AUTOFEATURE) i);
   }
@@ -3051,13 +3049,13 @@ gst_pylonsrc_read_colour_hue (GstPylonSrc * src, GST_PYLONSRC_COLOUR colour)
   if (is_prop_not_set (src, propColourHue[colour])) {
     GENAPIC_RESULT res = PylonDeviceFeatureFromString (src->deviceHandle,
         "ColorAdjustmentSelector", featColour[colour]);
-    if (res = GENAPI_E_OK) {
+    if (res == GENAPI_E_OK) {
       read_float_feature (src, "ColorAdjustmentHue", &src->hue[colour]);
     }
   }
 }
 
-static _Bool
+static void
 gst_pylonsrc_read_colour_saturation (GstPylonSrc * src,
     GST_PYLONSRC_COLOUR colour)
 {
@@ -3145,8 +3143,6 @@ gst_pylonsrc_read_manual_feature (GstPylonSrc * src,
 static void
 gst_pylonsrc_read_exposure_gain_level (GstPylonSrc * src)
 {
-  GENAPIC_RESULT res;
-
   for (int i = 0; i < AUTOF_NUM_LIMITED; i++) {
     gst_pylonsrc_read_manual_feature (src, (GST_PYLONSRC_AUTOFEATURE) i);
   }
@@ -3211,7 +3207,6 @@ static void
 gst_pylonsrc_read_trigger (GstPylonSrc * src)
 {
   if (is_prop_not_set (src, PROP_CONTINUOUSMODE)) {
-    const char *triggerSelectorValue = "FrameStart";
     _Bool isAvailAcquisitionStart =
         PylonDeviceFeatureIsAvailable (src->deviceHandle,
         "EnumEntry_TriggerSelector_AcquisitionStart");
@@ -3226,7 +3221,7 @@ gst_pylonsrc_read_trigger (GstPylonSrc * src)
   }
 }
 
-static _Bool
+static void
 gst_pylonsrc_read_resolution_axis (GstPylonSrc * src, GST_PYLONSRC_AXIS axis)
 {
   if (is_prop_not_set (src, propBinning[axis])) {

--- a/sys/pylon/gstpylonsrc.c
+++ b/sys/pylon/gstpylonsrc.c
@@ -191,15 +191,16 @@ typedef enum _GST_PYLONSRC_AUTOFEATURE
 G_STATIC_ASSERT ((int) AUTOF_NUM_FEATURES == GST_PYLONSRC_NUM_AUTO_FEATURES);
 G_STATIC_ASSERT ((int) AUTOF_NUM_LIMITED == GST_PYLONSRC_NUM_LIMITED_FEATURES);
 
-typedef struct _DemosaicingStrings {
-  const char* name;
-  const char* on;
-  const char* off;
+typedef struct _DemosaicingStrings
+{
+  const char *name;
+  const char *on;
+  const char *off;
 } DemosaicingStrings;
 
-static const DemosaicingStrings featDemosaicing[2] = { 
-  { "DemosaicingMode", "BaslerPGI", "Simple" },
-  { "PgiMode", "On", "Off" }
+static const DemosaicingStrings featDemosaicing[2] = {
+  {"DemosaicingMode", "BaslerPGI", "Simple"},
+  {"PgiMode", "On", "Off"}
 };
 static const char *const featAutoFeature[AUTOF_NUM_FEATURES] =
     { "GainAuto", "ExposureAuto", "BalanceWhiteAuto" };
@@ -474,62 +475,62 @@ gst_pylonsrc_class_init (GstPylonSrcClass * klass)
   g_object_class_install_property (gobject_class, PROP_COLORREDHUE,
       g_param_spec_double ("colorredhue", "Red's hue",
           "Specifies the red colour's hue. Note that the this value gets saved on the camera, and running this plugin again without specifying this value will cause the previous value being used. Use the reset parameter or reconnect the camera to reset.",
-          -4.0, 3.9, DEFAULT_PROP_HUE,
+          -128.0, 127.0, DEFAULT_PROP_HUE,
           (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
   g_object_class_install_property (gobject_class, PROP_COLORREDSATURATION,
       g_param_spec_double ("colorredsaturation", "Red's saturation",
           "Specifies the red colour's saturation. Note that the this value gets saved on the camera, and running this plugin again without specifying this value will cause the previous value being used. Use the reset parameter or reconnect the camera to reset.",
-          0.0, 1.9, DEFAULT_PROP_SATURATION,
+          0.0, 255.0, DEFAULT_PROP_SATURATION,
           (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
   g_object_class_install_property (gobject_class, PROP_COLORYELLOWHUE,
       g_param_spec_double ("coloryellowhue", "Yellow's hue",
           "Specifies the yellow colour's hue. Note that the this value gets saved on the camera, and running this plugin again without specifying this value will cause the previous value being used. Use the reset parameter or reconnect the camera to reset.",
-          -4.0, 3.9, DEFAULT_PROP_HUE,
+          -128.0, 127.0, DEFAULT_PROP_HUE,
           (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
   g_object_class_install_property (gobject_class, PROP_COLORYELLOWSATURATION,
       g_param_spec_double ("coloryellowsaturation", "Yellow's saturation",
           "Specifies the yellow colour's saturation. Note that the this value gets saved on the camera, and running this plugin again without specifying this value will cause the previous value being used. Use the reset parameter or reconnect the camera to reset.",
-          0.0, 1.9, DEFAULT_PROP_SATURATION,
+          0.0, 255.0, DEFAULT_PROP_SATURATION,
           (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
   g_object_class_install_property (gobject_class, PROP_COLORGREENHUE,
       g_param_spec_double ("colorgreenhue", "Green's hue",
           "Specifies the green colour's hue. Note that the this value gets saved on the camera, and running this plugin again without specifying this value will cause the previous value being used. Use the reset parameter or reconnect the camera to reset.",
-          -4.0, 3.9, DEFAULT_PROP_HUE,
+          -128.0, 127.0, DEFAULT_PROP_HUE,
           (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
   g_object_class_install_property (gobject_class, PROP_COLORGREENSATURATION,
       g_param_spec_double ("colorgreensaturation", "Green's saturation",
           "Specifies the green colour's saturation. Note that the this value gets saved on the camera, and running this plugin again without specifying this value will cause the previous value being used. Use the reset parameter or reconnect the camera to reset.",
-          0.0, 1.9, DEFAULT_PROP_SATURATION,
+          0.0, 255.0, DEFAULT_PROP_SATURATION,
           (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
   g_object_class_install_property (gobject_class, PROP_COLORCYANHUE,
       g_param_spec_double ("colorcyanhue", "Cyan's hue",
           "Specifies the cyan colour's hue. Note that the this value gets saved on the camera, and running this plugin again without specifying this value will cause the previous value being used. Use the reset parameter or reconnect the camera to reset.",
-          -4.0, 3.9, DEFAULT_PROP_HUE,
+          -128.0, 127.0, DEFAULT_PROP_HUE,
           (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
   g_object_class_install_property (gobject_class, PROP_COLORCYANSATURATION,
       g_param_spec_double ("colorcyansaturation", "Cyan's saturation",
           "Specifies the cyan colour's saturation. Note that the this value gets saved on the camera, and running this plugin again without specifying this value will cause the previous value being used. Use the reset parameter or reconnect the camera to reset.",
-          0.0, 1.9, DEFAULT_PROP_SATURATION,
+          0.0, 255.0, DEFAULT_PROP_SATURATION,
           (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
   g_object_class_install_property (gobject_class, PROP_COLORBLUEHUE,
       g_param_spec_double ("colorbluehue", "Blue's hue",
           "Specifies the blue colour's hue. Note that the this value gets saved on the camera, and running this plugin again without specifying this value will cause the previous value being used. Use the reset parameter or reconnect the camera to reset.",
-          -4.0, 3.9, DEFAULT_PROP_HUE,
+          -128.0, 127.0, DEFAULT_PROP_HUE,
           (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
   g_object_class_install_property (gobject_class, PROP_COLORBLUESATURATION,
       g_param_spec_double ("colorbluesaturation", "Blue's saturation",
           "Specifies the blue colour's saturation. Note that the this value gets saved on the camera, and running this plugin again without specifying this value will cause the previous value being used. Use the reset parameter or reconnect the camera to reset.",
-          0.0, 1.9, DEFAULT_PROP_SATURATION,
+          0.0, 255.0, DEFAULT_PROP_SATURATION,
           (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
   g_object_class_install_property (gobject_class, PROP_COLORMAGENTAHUE,
       g_param_spec_double ("colormagentahue", "Magenta's hue",
           "Specifies the magenta colour's hue. Note that the this value gets saved on the camera, and running this plugin again without specifying this value will cause the previous value being used. Use the reset parameter or reconnect the camera to reset.",
-          -4.0, 3.9, DEFAULT_PROP_HUE,
+          -128.0, 127.0, DEFAULT_PROP_HUE,
           (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
   g_object_class_install_property (gobject_class, PROP_COLORMAGENTASATURATION,
       g_param_spec_double ("colormagentasaturation", "Magenta's saturation",
           "Specifies the magenta colour's saturation. Note that the this value gets saved on the camera, and running this plugin again without specifying this value will cause the previous value being used. Use the reset parameter or reconnect the camera to reset.",
-          0.0, 1.9, DEFAULT_PROP_SATURATION,
+          0.0, 255.0, DEFAULT_PROP_SATURATION,
           (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
   g_object_class_install_property (gobject_class, PROP_COLORADJUSTMENTENABLE,
       g_param_spec_boolean ("coloradjustment", "Enable color adjustment",
@@ -544,12 +545,12 @@ gst_pylonsrc_class_init (GstPylonSrcClass * klass)
   g_object_class_install_property (gobject_class, PROP_GAIN,
       g_param_spec_double ("gain", "Gain",
           "(dB or raw) Sets the gain added on the camera before sending the frame to the computer. The value of this parameter will be saved to the camera, but it will be set to 0 every time this plugin is launched without specifying gain or overriden if the autogain parameter is set to anything that's not \"off\". Reconnect the camera or use the reset parameter to reset the stored value.",
-          0.0, 12.0, DEFAULT_PROP_LIMITED_MANUAL,
+          0.0, 1000.0, DEFAULT_PROP_LIMITED_MANUAL,
           (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
   g_object_class_install_property (gobject_class, PROP_BLACKLEVEL,
       g_param_spec_double ("blacklevel", "Black Level",
           "(DN) Sets stream's black level. This parameter is processed on the camera before the picture is sent to the computer. The value of this parameter will be saved to the camera, but it will be set to 0 every time this plugin is launched without specifying this parameter. Reconnect the camera or use the reset parameter to reset the stored value.",
-          0.0, 63.75, DEFAULT_PROP_BLACKLEVEL,
+          0.0, 1000.0, DEFAULT_PROP_BLACKLEVEL,
           (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
   g_object_class_install_property (gobject_class, PROP_GAMMA,
       g_param_spec_double ("gamma", "Gamma",
@@ -640,18 +641,18 @@ gst_pylonsrc_class_init (GstPylonSrcClass * klass)
           (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
   g_object_class_install_property (gobject_class, PROP_GAINUPPERLIMIT,
       g_param_spec_double ("gainupperlimit", "Auto gain upper limit",
-          "(0-12.00921 dB or raw) Sets the upper limit for the auto gain function.",
-          0.0, 12.00921, DEFAULT_PROP_GAINUPPERLIMIT,
+          "(0-1000 dB or raw) Sets the upper limit for the auto gain function.",
+          0.0, 1000.0, DEFAULT_PROP_GAINUPPERLIMIT,
           (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
   g_object_class_install_property (gobject_class, PROP_GAINLOWERLIMIT,
       g_param_spec_double ("gainlowerlimit", "Auto gain lower limit",
-          "(0-12.00921 dB or raw) Sets the lower limit for the auto gain function.",
-          0.0, 12.00921, DEFAULT_PROP_GAINLOWERLIMIT,
+          "(0-1000 dB or raw) Sets the lower limit for the auto gain function.",
+          0.0, 1000.0, DEFAULT_PROP_GAINLOWERLIMIT,
           (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
   g_object_class_install_property (gobject_class, PROP_AUTOBRIGHTNESSTARGET,
       g_param_spec_double ("autobrightnesstarget", "Auto brightness target",
           "(0.19608-0.80392 or 50-205) Sets the brightness value the auto exposure/gain function should strive for.",
-          0.19608, 0.80392, DEFAULT_PROP_AUTOBRIGHTNESSTARGET,
+          0.19608, 205.0, DEFAULT_PROP_AUTOBRIGHTNESSTARGET,
           (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
   g_object_class_install_property (gobject_class, PROP_AUTOPROFILE,
       g_param_spec_string ("autoprofile", "Auto function minimize profile",
@@ -2084,8 +2085,7 @@ gst_pylonsrc_set_framerate (GstPylonSrc * src)
   if (is_prop_implicit (src, PROP_FPS)) {
     if (is_prop_set (src, PROP_FPS)) {
       // apply only if it is set explicitly (default is zero)
-      const char *fps =
-          feature_alias_available (src, "AcquisitionFrameRate",
+      const char *fps = feature_alias_available (src, "AcquisitionFrameRate",
           "AcquisitionFrameRateAbs");
       if (fps != NULL) {
         res = PylonDeviceSetFloatFeature (src->deviceHandle, fps, src->fps);
@@ -2111,8 +2111,7 @@ gst_pylonsrc_set_lightsource (GstPylonSrc * src)
   char *original = NULL;
   if (is_prop_implicit (src, PROP_LIGHTSOURCE)) {
     // Set lightsource preset
-    const char *preset =
-        feature_alias_available (src, "LightSourcePreset",
+    const char *preset = feature_alias_available (src, "LightSourcePreset",
         "LightSourceSelector");
     if (preset == NULL && feature_available (src, "BslLightSourcePreset")) {
       preset = "BslLightSourcePreset";
@@ -2426,8 +2425,7 @@ gst_pylonsrc_set_colour_hue (GstPylonSrc * src, GST_PYLONSRC_COLOUR colour)
             selector, featColour[colour]);
         PYLONC_CHECK_ERROR (src, res);
 
-        const char *hue =
-            feature_alias_available (src, "ColorAdjustmentHue",
+        const char *hue = feature_alias_available (src, "ColorAdjustmentHue",
             "BslColorAdjustmentHue");
         if (hue != NULL) {
           res =
@@ -2716,7 +2714,8 @@ gst_pylonsrc_set_pgi (GstPylonSrc * src)
 {
   if (is_prop_implicit (src, PROP_BASLERDEMOSAICING)) {
     const char *demosaicing =
-        feature_alias_available (src, featDemosaicing[0].name, featDemosaicing[1].name);
+        feature_alias_available (src, featDemosaicing[0].name,
+        featDemosaicing[1].name);
     if (demosaicing != NULL) {
       GENAPIC_RESULT res;
       ptrdiff_t idx = (demosaicing == featDemosaicing[0].name) ? 0 : 1;
@@ -2905,8 +2904,7 @@ gst_pylonsrc_configure_start_acquisition (GstPylonSrc * src)
         readoutTime);
   }
   // Output final frame rate [Hz]
-  const char *name =
-      feature_alias_available (src, "ResultingFrameRate",
+  const char *name = feature_alias_available (src, "ResultingFrameRate",
       "ResultingFrameRateAbs");
   if (name != NULL) {
     double frameRate = 0.0;
@@ -3439,7 +3437,8 @@ gst_pylonsrc_read_pgi (GstPylonSrc * src)
 {
   if (is_prop_not_set (src, PROP_BASLERDEMOSAICING)) {
     const char *demosaicing =
-        feature_alias_readable (src, featDemosaicing[0].name, featDemosaicing[1].name);
+        feature_alias_readable (src, featDemosaicing[0].name,
+        featDemosaicing[1].name);
     if (demosaicing != NULL) {
       const ptrdiff_t idx = (demosaicing == featDemosaicing[0].name) ? 0 : 1;
       const char *pgiOn = featDemosaicing[idx].on;
@@ -3872,12 +3871,11 @@ pylonc_print_camera_info (GstPylonSrc * src, PYLON_DEVICE_HANDLE deviceHandle,
     res =
         PylonDeviceFeatureToString (deviceHandle, "DeviceSerialNumber", serial,
         &siz);
-    if(siz <= 2 || res != GENAPI_E_OK) {
-      if(PylonDeviceFeatureIsReadable(deviceHandle, "DeviceID")) {
+    if (siz <= 2 || res != GENAPI_E_OK) {
+      if (PylonDeviceFeatureIsReadable (deviceHandle, "DeviceID")) {
         siz = sizeof (serial);
         res =
-          PylonDeviceFeatureToString (deviceHandle, "DeviceID", serial,
-          &siz);
+            PylonDeviceFeatureToString (deviceHandle, "DeviceID", serial, &siz);
       } else {
         serial[0] = '0';
         serial[1] = '\0';

--- a/sys/pylon/gstpylonsrc.h
+++ b/sys/pylon/gstpylonsrc.h
@@ -39,7 +39,7 @@ enum
   GST_PYLONSRC_NUM_CAPTURE_BUFFERS = 10,
   GST_PYLONSRC_NUM_AUTO_FEATURES = 3,
   GST_PYLONSRC_NUM_LIMITED_FEATURES = 2,
-  GST_PYLONSRC_NUM_PROPS = 66
+  GST_PYLONSRC_NUM_PROPS = 67
 };
 
 typedef enum _GST_PYLONSRC_PROPERTY_STATE
@@ -86,7 +86,7 @@ struct _GstPylonSrc
   guint64 frameNumber;          // Fun note: At 120fps it will take around 4 billion years to overflow this variable.
 
   // Plugin parameters
-  _Bool setFPS, continuousMode, limitBandwidth, demosaicing;
+  _Bool setFPS, continuousMode, limitBandwidth, demosaicing, colorAdjustment;
   _Bool center[2];
   _Bool flip[2];
   _Bool ignoreDefaults;


### PR DESCRIPTION
This PR generally resolves issues [#47](https://github.com/joshdoe/gst-plugins-vision/issues/47) and [#48](https://github.com/joshdoe/gst-plugins-vision/issues/48). And property handling modifications I've mentioned [here](https://github.com/joshdoe/gst-plugins-vision/pull/46#issuecomment-765364197)
I've tested it on acA720-290gm and acA2040-55uc. This pair is a fairly good example of feature name duplicates. However they do not cover all of the possible aliases.