### PR TITLE
Add in TestImageSource parameter to allow for custom images

### DIFF
--- a/sys/pylon/gstpylonsrc.c
+++ b/sys/pylon/gstpylonsrc.c
@@ -4264,8 +4264,7 @@ pylonc_print_camera_info (GstPylonSrc * src, PYLON_DEVICE_HANDLE deviceHandle,
   size_t siz = 0;
   GENAPIC_RESULT res;
 
-  if (PylonDeviceFeatureIsReadable (deviceHandle, "DeviceModelName")
-      && PylonDeviceFeatureIsReadable (deviceHandle, "DeviceSerialNumber")) {
+  if (PylonDeviceFeatureIsAvailable (deviceHandle, "DeviceModelName")) {
     siz = sizeof (name);
     res =
         PylonDeviceFeatureToString (deviceHandle, "DeviceModelName", name,

--- a/sys/pylon/gstpylonsrc.c
+++ b/sys/pylon/gstpylonsrc.c
@@ -4132,13 +4132,13 @@ gst_pylonsrc_create (GstPushSrc * psrc, GstBuffer ** buf)
     if (grabResult.Status != Grabbed) {
       src->failedFrames += 1;
       GST_WARNING_OBJECT (src,
-          "Failed capture count=%d. Status=%d, ErrorCode=%d", src->failedFrames,
+          "Failed capture count=%d. Status=%d, ErrorCode=0x%.8X", src->failedFrames,
           grabResult.Status, grabResult.ErrorCode);
     } else
       src->failedFrames = 0;
   } else {
     GST_ERROR_OBJECT (src,
-        "Error in the image processing loop. Status=%d, ErrorCode=%d",
+        "Error in the image processing loop. Status=%d, ErrorCode=0x%.8X",
         grabResult.Status, grabResult.ErrorCode);
     goto error;
   }

--- a/sys/pylon/gstpylonsrc.c
+++ b/sys/pylon/gstpylonsrc.c
@@ -2152,7 +2152,8 @@ error:
 static gboolean
 gst_pylonsrc_set_test_image_source (GstPylonSrc * src)
 {
-  if (!(is_prop_default (src, PROP_TESTIMAGESOURCE))) {
+  if (is_prop_implicit (src, PROP_TESTIMAGESOURCE) &&
+      !(is_prop_default (src, PROP_TESTIMAGESOURCE))) {
     // Set whether test image will be shown
     if (feature_supported (src, "ImageFilename")) {
       GENAPIC_RESULT res;

--- a/sys/pylon/gstpylonsrc.c
+++ b/sys/pylon/gstpylonsrc.c
@@ -2152,7 +2152,7 @@ error:
 static gboolean
 gst_pylonsrc_set_test_image_source (GstPylonSrc * src)
 {
-  if (is_prop_implicit (src, PROP_TESTIMAGESOURCE)) {
+  if (!(is_prop_default (src, PROP_TESTIMAGESOURCE))) {
     // Set whether test image will be shown
     if (feature_supported (src, "ImageFilename")) {
       GENAPIC_RESULT res;

--- a/sys/pylon/gstpylonsrc.h
+++ b/sys/pylon/gstpylonsrc.h
@@ -39,7 +39,7 @@ enum
   GST_PYLONSRC_NUM_CAPTURE_BUFFERS = 10,
   GST_PYLONSRC_NUM_AUTO_FEATURES = 3,
   GST_PYLONSRC_NUM_LIMITED_FEATURES = 2,
-  GST_PYLONSRC_NUM_PROPS = 74
+  GST_PYLONSRC_NUM_PROPS = 75
 };
 
 typedef enum _GST_PYLONSRC_PROPERTY_STATE
@@ -107,7 +107,7 @@ struct _GstPylonSrc
   gint maxSize[2];
   gint offset[2];
   gchar *pixel_format, *sensorMode, *lightsource, *reset, *autoprofile,
-      *transformationselector, *userid;
+      *transformationselector, *userid, *testImageSource;
   gchar *autoFeature[GST_PYLONSRC_NUM_AUTO_FEATURES];
   gchar *configFile;
   GST_PYLONSRC_PROPERTY_STATE propFlags[GST_PYLONSRC_NUM_PROPS];


### PR DESCRIPTION
This TestImageSource parameter enables more meaningful image emulations compared to the default pylon test images.