### PR TITLE
pleora: Fixes find_path for Pleora_LIBRARY_DIR on Windows

### DIFF
--- a/cmake/modules/FindPleora.cmake
+++ b/cmake/modules/FindPleora.cmake
@@ -32,7 +32,7 @@ find_path (Pleora_INCLUDE_DIR PvBase.h
     PATH_SUFFIXES Includes include)
 message (STATUS "Found Pleora include dir in ${Pleora_INCLUDE_DIR}")
 
-find_path (Pleora_LIBRARY_DIR NAMES libPvBase.so "PvBase${_LIB_NAME}"
+find_path (Pleora_LIBRARY_DIR NAMES libPvBase.so "PvBase${_LIB_SUFFIX}.lib"
     PATHS ${_Pleora_PATHS}
     PATH_SUFFIXES Libraries lib)
 


### PR DESCRIPTION
Fixes typo in Pleora_LIBRARY_DIR "PvBase${_LIB_NAME}" -> "PvBase${_LIB_SUFFIX}.lib"